### PR TITLE
feat: add caddy reverse proxy with security headers

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -16,7 +16,7 @@ services:
     ports:
       - "${CADDY_HTTP_PORT:-8080}:8080"
     volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile
+      - ./deploy/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
     depends_on:
       - api
       - front

--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -1,0 +1,43 @@
+{
+    auto_https off
+}
+
+:8080 {
+    # TLS placeholder for production
+    # tls /path/to/cert /path/to/key
+
+    header {
+        Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+        Content-Security-Policy "default-src 'self'"
+        X-Frame-Options "DENY"
+        Referrer-Policy "no-referrer"
+    }
+
+    @internal path /_internal/*
+    basicauth @internal {
+        admin $2a$14$Ne5KpSd/dhMtvPR03k3tZ.o9Xa0Jm8fz72ClMi1WQ250rVcVgojwi
+    }
+
+    handle_path /_internal/grafana/* {
+        reverse_proxy grafana:3000
+    }
+    handle_path /_internal/prometheus/* {
+        reverse_proxy prometheus:9090
+    }
+    handle_path /_internal/dozzle/* {
+        reverse_proxy dozzle:8080
+    }
+
+    handle_path /api/* {
+        reverse_proxy api:8001
+    }
+
+    handle /healthz {
+        reverse_proxy api:8001
+    }
+
+    # Serve frontend static (uncomment to serve built assets)
+    # root * /srv/frontend
+    # file_server
+    reverse_proxy front:5173
+}


### PR DESCRIPTION
## Summary
- add Caddyfile with security headers and basic auth for internal dashboards
- mount new Caddyfile in compose caddy service

## Testing
- `curl -i http://localhost:8080/healthz`

------
https://chatgpt.com/codex/tasks/task_e_68a1e9c99b688330b461af60fb04d7fe