### PR TITLE
Fix flake8 issues in tests

### DIFF
--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,2 +1,1 @@
 """Test package."""
-

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -10,6 +10,7 @@ from app.security import get_redis, hash_password
 
 TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
 
+
 @pytest_asyncio.fixture
 async def async_client() -> AsyncClient:
     engine = create_async_engine(TEST_DB_URL)
@@ -40,7 +41,10 @@ async def async_client() -> AsyncClient:
         session.add(admin)
         await session.commit()
 
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
         yield client
 
     app.dependency_overrides.clear()

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -1,8 +1,12 @@
 import pytest
 
+
 @pytest.mark.asyncio
 async def test_create_user(async_client):
-    resp = await async_client.post("/auth/token", data={"username": "admin", "password": "admin"})
+    resp = await async_client.post(
+        "/auth/token",
+        data={"username": "admin", "password": "admin"},
+    )
     token = resp.json()["access_token"]
     headers = {"Authorization": f"Bearer {token}"}
     payload = {
@@ -11,6 +15,10 @@ async def test_create_user(async_client):
         "password": "secret",
         "role": "intermittent",
     }
-    resp = await async_client.post("/admin/users", json=payload, headers=headers)
+    resp = await async_client.post(
+        "/admin/users",
+        json=payload,
+        headers=headers,
+    )
     assert resp.status_code == 200
     assert resp.json()["username"] == "bob"

--- a/backend/tests/test_assignments.py
+++ b/backend/tests/test_assignments.py
@@ -1,6 +1,7 @@
 import pytest
 from datetime import datetime, timedelta
 
+
 @pytest.mark.asyncio
 async def test_assignment_crud(async_client):
     resp = await async_client.post(


### PR DESCRIPTION
## Summary
- fix spacing and line length problems in test_admin and test_assignments
- clean up test utilities to satisfy flake8

## Testing
- `flake8 tests && echo 'flake8 passed'`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68a20486ec9483308180bdb90d40310a