### PR TITLE
Add security docs and probe script

### DIFF
--- a/deploy/security/backups_restore.md
+++ b/deploy/security/backups_restore.md
@@ -1,0 +1,10 @@
+# Backups and Restore
+
+## Postgres
+
+- Create backups with `pg_dump`.
+- Restore data with `pg_restore`.
+
+## Object Storage
+
+- Store dumps in S3 with lifecycle rules for retention and archival.

--- a/deploy/security/hardening_checklist.md
+++ b/deploy/security/hardening_checklist.md
@@ -1,0 +1,8 @@
+# Application Hardening Checklist
+
+- **Content-Security-Policy (CSP)** and **Strict-Transport-Security (HSTS)** headers enabled.
+- **CORS** restricted to trusted origins only.
+- **Rate limits** enforced for write and login operations.
+- **JWT/opaque tokens** rotated regularly.
+- **Secrets** rotated on schedule and stored securely.
+- **File uploads** limited to 5MB; optional **antivirus** scanning.

--- a/deploy/security/incident_runbook.md
+++ b/deploy/security/incident_runbook.md
@@ -1,0 +1,5 @@
+# Incident Runbook
+
+- Perform **rollbacks** to revert problematic deployments.
+- Toggle **feature flags** to disable features quickly.
+- Temporarily raise **rate limits** to absorb spikes while mitigating.

--- a/scripts/security_probe.ps1
+++ b/scripts/security_probe.ps1
@@ -1,0 +1,33 @@
+param(
+    [string]$BaseUrl = "http://localhost:8000"
+)
+
+function Check-Headers {
+    param([string]$Url)
+    $headers = curl -s -D - -o /dev/null $Url
+    if ($headers -match 'Content-Security-Policy' -and $headers -match 'Strict-Transport-Security' -and $headers -match 'Access-Control-Allow-Origin') {
+        Write-Output "Headers OK"
+    } else {
+        Write-Output "Missing security headers"
+        exit 1
+    }
+}
+
+function Check-LargeUpload {
+    param([string]$Url)
+    $temp = New-TemporaryFile
+    $bytes = New-Object Byte[] (6MB)
+    [System.Random]::new().NextBytes($bytes)
+    [System.IO.File]::WriteAllBytes($temp, $bytes)
+    $status = curl -s -o /dev/null -w "%{http_code}" -X POST --data-binary @$temp $Url
+    Remove-Item $temp
+    if ($status -eq 413) {
+        Write-Output "Large upload rejected with 413"
+    } else {
+        Write-Output "Unexpected status: $status"
+        exit 1
+    }
+}
+
+Check-Headers $BaseUrl
+Check-LargeUpload $BaseUrl


### PR DESCRIPTION
## Summary
- document hardening requirements, backups, and incident responses under deploy/security
- add PowerShell probe to verify security headers and upload limits

## Testing
- `pwsh scripts/security_probe.ps1`
- `pwsh scripts/test_all.ps1` *(fails: browserType.launch: Executable doesn't exist; 'k6' not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68a2096461b48330bcbeb0f61c8c52fa