### PR TITLE
fix: resolve flake8 errors in user schema and security module

### DIFF
--- a/backend/app/schemas/users.py
+++ b/backend/app/schemas/users.py
@@ -1,14 +1,17 @@
 from datetime import datetime
 from pydantic import BaseModel, Field
 
+
 class UserBase(BaseModel):
     username: str
     email: str
     role: str = "intermittent"
     prefs: dict = Field(default_factory=dict)
 
+
 class UserIn(UserBase):
     password: str
+
 
 class UserOut(UserBase):
     id: int

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -1,5 +1,4 @@
 import secrets
-from datetime import timedelta
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from passlib.context import CryptContext


### PR DESCRIPTION
## Summary
- add missing blank lines in user schema definitions
- remove unused `timedelta` import from security module

## Testing
- `flake8 backend` *(fails: multiple existing style violations)*
- `flake8 backend/app/schemas/users.py backend/app/security.py`
- `pytest backend`


------
https://chatgpt.com/codex/tasks/task_e_68a20f4d9948833094e05c29aa86f17a