### PR TITLE
Fix style issues in backend schemas and security module

### DIFF
--- a/backend/app/schemas/missions.py
+++ b/backend/app/schemas/missions.py
@@ -2,10 +2,12 @@ from datetime import datetime
 from typing import List
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+
 class Position(BaseModel):
     label: str
     count: int = Field(..., ge=1)
     skills: dict = Field(default_factory=dict)
+
 
 class MissionBase(BaseModel):
     title: str
@@ -32,8 +34,10 @@ class MissionBase(BaseModel):
             raise ValueError("position labels must be unique")
         return self
 
+
 class MissionIn(MissionBase):
     pass
+
 
 class MissionOut(MissionBase):
     id: int

--- a/backend/app/schemas/users.py
+++ b/backend/app/schemas/users.py
@@ -1,14 +1,17 @@
 from datetime import datetime
 from pydantic import BaseModel, Field
 
+
 class UserBase(BaseModel):
     username: str
     email: str
     role: str = "intermittent"
     prefs: dict = Field(default_factory=dict)
 
+
 class UserIn(UserBase):
     password: str
+
 
 class UserOut(UserBase):
     id: int

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -1,5 +1,4 @@
 import secrets
-from datetime import timedelta
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from passlib.context import CryptContext


### PR DESCRIPTION
## Summary
- ensure two blank lines before mission and user schema classes
- remove unused import from security module

## Testing
- `flake8 backend/app/schemas/missions.py backend/app/schemas/users.py backend/app/security.py`
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2124af6f88330b65150f0d71db50d