### PR TITLE
Fix planning router style issues

### DIFF
--- a/backend/app/routers/planning.py
+++ b/backend/app/routers/planning.py
@@ -5,8 +5,13 @@ from ..security import require_auth, get_redis
 
 router = APIRouter(prefix="/planning", tags=["planning"])
 
+
 @router.get("/week/{week}")
-async def planning_week(week: int, redis = Depends(get_redis), user=Depends(require_auth)):
+async def planning_week(
+    week: int,
+    redis=Depends(get_redis),
+    user=Depends(require_auth),
+):
     key = f"planning:{week}"
     cached = await redis.get(key)
     if cached:


### PR DESCRIPTION
## Summary
- resolve flake8 style errors in planning router
- wrap long function definition and remove extra spaces

## Testing
- `python -m flake8 backend/app/routers/planning.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a215b748188330a461961905a7dd9c