### PR TITLE
feat: add auth client and login flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hot-toast": "^2.4.1",
-        "react-router-dom": "^6.21.2"
+        "react-router-dom": "^6.21.2",
+        "zustand": "^4.5.2"
       },
       "devDependencies": {
         "@types/react": "^18.2.21",
@@ -1417,14 +1418,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -4266,6 +4267,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -4498,6 +4508,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hot-toast": "^2.4.1",
-    "react-router-dom": "^6.21.2"
+    "react-router-dom": "^6.21.2",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@types/react": "^18.2.21",

--- a/src/app/layouts/DashboardLayout.tsx
+++ b/src/app/layouts/DashboardLayout.tsx
@@ -1,11 +1,16 @@
 import { Outlet } from 'react-router-dom';
+import { useAuthStore } from '../store/auth';
+import { useMe } from '../../hooks/useAuth';
 
 export default function DashboardLayout() {
+  useMe();
+  const me = useAuthStore((s) => s.me);
   return (
     <div className="min-h-screen flex flex-col">
       <header className="bg-gray-100 dark:bg-gray-900 shadow">
-        <div className="container mx-auto px-4 py-3">
+        <div className="container mx-auto px-4 py-3 flex justify-between">
           <span className="font-semibold">Coulisses Crew</span>
+          {me && <span>{me.name}</span>}
         </div>
       </header>
       <main className="flex-1 container mx-auto p-4">
@@ -14,3 +19,4 @@ export default function DashboardLayout() {
     </div>
   );
 }
+

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,8 +1,11 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import DashboardLayout from './layouts/DashboardLayout';
+import Login from '../pages/Login';
+import Dashboard from '../pages/Dashboard';
+import { useAuthStore } from './store/auth';
 
 function ProtectedRoute({ children }: { children: JSX.Element }) {
-  const token = localStorage.getItem('token');
+  const token = useAuthStore((s) => s.token);
   if (!token) {
     return <Navigate to="/login" replace />;
   }
@@ -13,7 +16,7 @@ export default function Router() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/login" element={<div>Login</div>} />
+        <Route path="/login" element={<Login />} />
         <Route
           path="/"
           element={
@@ -23,10 +26,11 @@ export default function Router() {
           }
         >
           <Route index element={<Navigate to="/dashboard" replace />} />
-          <Route path="dashboard" element={<div>Dashboard</div>} />
+          <Route path="dashboard" element={<Dashboard />} />
         </Route>
         <Route path="*" element={<div>Not Found</div>} />
       </Routes>
     </BrowserRouter>
   );
 }
+

--- a/src/app/store/auth.ts
+++ b/src/app/store/auth.ts
@@ -1,0 +1,40 @@
+import { create } from 'zustand';
+
+export interface UserPrefs {
+  [key: string]: unknown;
+}
+
+export interface User {
+  id: string;
+  name: string;
+  prefs?: UserPrefs;
+}
+
+interface AuthState {
+  token: string | null;
+  me: User | null;
+  login: (token: string) => void;
+  logout: () => void;
+  setPrefs: (prefs: UserPrefs) => void;
+}
+
+const tokenKey = 'token';
+const initialToken = typeof localStorage !== 'undefined' ? localStorage.getItem(tokenKey) : null;
+
+export const useAuthStore = create<AuthState>((set) => ({
+  token: initialToken,
+  me: null,
+  login: (token) => {
+    localStorage.setItem(tokenKey, token);
+    set({ token });
+  },
+  logout: () => {
+    localStorage.removeItem(tokenKey);
+    set({ token: null, me: null });
+  },
+  setPrefs: (prefs) =>
+    set((state) =>
+      state.me ? { me: { ...state.me, prefs } } : state
+    ),
+}));
+

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,48 @@
+import { useEffect } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { http } from '../lib/http';
+import { useAuthStore, User, UserPrefs } from '../app/store/auth';
+
+type LoginInput = { username: string; password: string };
+export function useLogin() {
+  const login = useAuthStore((s) => s.login);
+  return useMutation({
+    mutationFn: (data: LoginInput) =>
+      http<{ token: string }>('/auth/token-json', {
+        method: 'POST',
+        body: data,
+      }),
+    onSuccess: (data) => {
+      login(data.token);
+    },
+  });
+}
+
+export function useMe(options?: { enabled?: boolean }) {
+  const token = useAuthStore((s) => s.token);
+  const query = useQuery<User>({
+    queryKey: ['me', token],
+    queryFn: () => http<User>('/auth/me'),
+    enabled: options?.enabled ?? Boolean(token),
+  });
+  useEffect(() => {
+    if (query.data) {
+      useAuthStore.setState({ me: query.data });
+    }
+  }, [query.data]);
+  return query;
+}
+
+export function useUpdatePrefs() {
+  const setPrefs = useAuthStore((s) => s.setPrefs);
+  return useMutation({
+    mutationFn: (prefs: UserPrefs) =>
+      http<User>('/auth/me/prefs', { method: 'PUT', body: prefs }),
+    onSuccess: (user) => {
+      if (user.prefs) {
+        setPrefs(user.prefs);
+      }
+    },
+  });
+}
+

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,0 +1,73 @@
+import { useAuthStore } from '../app/store/auth';
+
+export const API_BASE = import.meta.env.VITE_API_BASE as string;
+
+interface HttpOptions {
+  method?: string;
+  body?: unknown;
+  headers?: Record<string, string>;
+}
+
+interface HttpError {
+  message: string;
+  status: number;
+}
+
+async function request(path: string, options: HttpOptions = {}, retry = false): Promise<Response> {
+  const token = useAuthStore.getState().token;
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    ...options.headers,
+  };
+  let body: BodyInit | undefined;
+  if (options.body !== undefined) {
+    headers['Content-Type'] = 'application/json';
+    body = JSON.stringify(options.body);
+  }
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: options.method ?? 'GET',
+    headers,
+    body,
+    credentials: 'include',
+  });
+  if (res.status === 401 && !retry) {
+    try {
+      const refresh = await fetch(`${API_BASE}/auth/refresh`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+      if (refresh.ok) {
+        const data: { token: string } = await refresh.json();
+        useAuthStore.getState().login(data.token);
+        return request(path, options, true);
+      }
+    } catch {
+      // ignore
+    }
+    useAuthStore.getState().logout();
+  }
+  return res;
+}
+
+export async function http<T>(path: string, opts: HttpOptions = {}): Promise<T> {
+  const res = await request(path, opts);
+  if (!res.ok) {
+    let message = res.statusText;
+    try {
+      const data = await res.json();
+      message = (data as { message?: string }).message ?? message;
+    } catch {
+      // ignore
+    }
+    const error: HttpError = { message, status: res.status };
+    throw error;
+  }
+  if (res.status === 204) {
+    return undefined as T;
+  }
+  return (await res.json()) as T;
+}
+

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,3 @@
+export default function Dashboard() {
+  return <div>Dashboard</div>;
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,75 @@
+import { FormEvent, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useLogin, useMe } from '../hooks/useAuth';
+
+export default function Login() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+  const login = useLogin();
+  const meQuery = useMe({ enabled: false });
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!username || !password) {
+      setError('Username and password are required');
+      return;
+    }
+    setError(null);
+    try {
+      await login.mutateAsync({ username, password });
+      await meQuery.refetch();
+      navigate('/dashboard', { replace: true });
+    } catch (err) {
+      const message = (err as { message?: string }).message ?? 'Login failed';
+      setError(message);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <form
+        onSubmit={onSubmit}
+        className="w-80 p-6 bg-white rounded shadow space-y-4"
+      >
+        <h1 className="text-xl font-semibold text-center">Login</h1>
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <div>
+          <label htmlFor="username" className="block text-sm font-medium">
+            Username
+          </label>
+          <input
+            id="username"
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            className="mt-1 block w-full border rounded px-3 py-2"
+            required
+          />
+        </div>
+        <div>
+          <label htmlFor="password" className="block text-sm font-medium">
+            Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="mt-1 block w-full border rounded px-3 py-2"
+            required
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={login.isPending}
+          className="w-full bg-blue-600 text-white py-2 rounded"
+        >
+          {login.isPending ? 'Logging in...' : 'Login'}
+        </button>
+      </form>
+    </div>
+  );
+}
+

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- add fetch wrapper with token refresh/logout handling
- create zustand auth store and hooks for login, me and prefs
- build login page and display user name in dashboard topbar

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a227543c688330a7f0d0f398ee9cdb