### PR TITLE
feat: add typed services and hooks

### DIFF
--- a/src/app/layouts/DashboardLayout.tsx
+++ b/src/app/layouts/DashboardLayout.tsx
@@ -10,7 +10,7 @@ export default function DashboardLayout() {
       <header className="bg-gray-100 dark:bg-gray-900 shadow">
         <div className="container mx-auto px-4 py-3 flex justify-between">
           <span className="font-semibold">Coulisses Crew</span>
-          {me && <span>{me.name}</span>}
+          {me && <span>{me.username}</span>}
         </div>
       </header>
       <main className="flex-1 container mx-auto p-4">

--- a/src/app/store/auth.ts
+++ b/src/app/store/auth.ts
@@ -1,14 +1,5 @@
 import { create } from 'zustand';
-
-export interface UserPrefs {
-  [key: string]: unknown;
-}
-
-export interface User {
-  id: string;
-  name: string;
-  prefs?: UserPrefs;
-}
+import type { User, UserPrefs } from '../../types/user';
 
 interface AuthState {
   token: string | null;
@@ -33,8 +24,5 @@ export const useAuthStore = create<AuthState>((set) => ({
     set({ token: null, me: null });
   },
   setPrefs: (prefs) =>
-    set((state) =>
-      state.me ? { me: { ...state.me, prefs } } : state
-    ),
+    set((state) => (state.me ? { me: { ...state.me, prefs } } : state)),
 }));
-

--- a/src/hooks/useAccounting.ts
+++ b/src/hooks/useAccounting.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import * as service from '../services/accounting';
+
+export function useAccountingSummary(params?: service.SummaryParams) {
+  return useQuery({
+    queryKey: ['accounting', params],
+    queryFn: () => service.getSummary(params),
+  });
+}
+
+export function useExportCsv() {
+  return useMutation({
+    mutationFn: (params?: service.SummaryParams) => service.exportCsv(params),
+  });
+}

--- a/src/hooks/useAssignments.ts
+++ b/src/hooks/useAssignments.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import * as service from '../services/assignments';
+import type { AssignmentInput } from '../types/assignment';
+
+export function useAssignments(missionId: number) {
+  return useQuery({
+    queryKey: ['assignments', missionId],
+    queryFn: () => service.listAssignments(missionId),
+    enabled: typeof missionId === 'number',
+  });
+}
+
+export function useAssignmentsAdd() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: AssignmentInput) => service.addAssignment(data),
+    onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: ['assignments', data.mission_id] });
+    },
+  });
+}
+
+export function useAssignmentsUpdate() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { id: number; data: Partial<AssignmentInput> }) =>
+      service.updateAssignment(vars.id, vars.data),
+    onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: ['assignments', data.mission_id] });
+    },
+  });
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,19 +1,15 @@
 import { useEffect } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { http } from '../lib/http';
-import { useAuthStore, User, UserPrefs } from '../app/store/auth';
+import { useAuthStore } from '../app/store/auth';
+import { login, getMe, updatePrefs } from '../services/auth';
+import type { User, UserPrefs } from '../types/user';
 
-type LoginInput = { username: string; password: string };
 export function useLogin() {
-  const login = useAuthStore((s) => s.login);
+  const loginStore = useAuthStore((s) => s.login);
   return useMutation({
-    mutationFn: (data: LoginInput) =>
-      http<{ token: string }>('/auth/token-json', {
-        method: 'POST',
-        body: data,
-      }),
+    mutationFn: login,
     onSuccess: (data) => {
-      login(data.token);
+      loginStore(data.token);
     },
   });
 }
@@ -22,7 +18,7 @@ export function useMe(options?: { enabled?: boolean }) {
   const token = useAuthStore((s) => s.token);
   const query = useQuery<User>({
     queryKey: ['me', token],
-    queryFn: () => http<User>('/auth/me'),
+    queryFn: getMe,
     enabled: options?.enabled ?? Boolean(token),
   });
   useEffect(() => {
@@ -36,8 +32,7 @@ export function useMe(options?: { enabled?: boolean }) {
 export function useUpdatePrefs() {
   const setPrefs = useAuthStore((s) => s.setPrefs);
   return useMutation({
-    mutationFn: (prefs: UserPrefs) =>
-      http<User>('/auth/me/prefs', { method: 'PUT', body: prefs }),
+    mutationFn: (prefs: UserPrefs) => updatePrefs(prefs),
     onSuccess: (user) => {
       if (user.prefs) {
         setPrefs(user.prefs);
@@ -45,4 +40,3 @@ export function useUpdatePrefs() {
     },
   });
 }
-

--- a/src/hooks/useAvailability.ts
+++ b/src/hooks/useAvailability.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import * as service from '../services/availability';
+
+export function useAvailability() {
+  return useQuery({
+    queryKey: ['availability'],
+    queryFn: service.getAvailability,
+  });
+}
+
+export function useAvailabilityUpdate() {
+  return useMutation({
+    mutationFn: service.updateAvailability,
+  });
+}
+
+export function useAvailabilityIcs() {
+  return useMutation({
+    mutationFn: service.downloadIcs,
+  });
+}

--- a/src/hooks/useFiles.ts
+++ b/src/hooks/useFiles.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import * as service from '../services/files';
+
+export function useFilesList(missionId: number) {
+  return useQuery({
+    queryKey: ['files', missionId],
+    queryFn: () => service.listFiles(missionId),
+    enabled: typeof missionId === 'number',
+  });
+}
+
+export function useUploadFile(missionId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (file: File) => service.uploadFile(missionId, file),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['files', missionId] }),
+  });
+}
+
+export function useMissionIcs(missionId: number) {
+  return useMutation({
+    mutationFn: () => service.downloadIcs(missionId),
+  });
+}

--- a/src/hooks/useMissionActions.ts
+++ b/src/hooks/useMissionActions.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import * as actions from '../services/missionActions';
+
+export function usePublish(id: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => actions.publishMission(id),
+    onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: ['missions'] });
+      qc.setQueryData(['mission', id], data);
+    },
+  });
+}
+
+export function useDuplicate(id: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: actions.DuplicateBody) => actions.duplicateMission(id, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['missions'] });
+    },
+  });
+}
+
+export function useClose(id: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => actions.closeMission(id),
+    onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: ['missions'] });
+      qc.setQueryData(['mission', id], data);
+    },
+  });
+}
+
+export function useCancel(id: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => actions.cancelMission(id),
+    onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: ['missions'] });
+      qc.setQueryData(['mission', id], data);
+    },
+  });
+}

--- a/src/hooks/useMissions.ts
+++ b/src/hooks/useMissions.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import * as service from '../services/missions';
+import type { MissionInput } from '../types/mission';
+
+export function useMissionsList(params?: service.MissionListParams) {
+  return useQuery({
+    queryKey: ['missions', params],
+    queryFn: () => service.listMissions(params),
+  });
+}
+
+export function useMission(id: number) {
+  return useQuery({
+    queryKey: ['mission', id],
+    queryFn: () => service.getMission(id),
+    enabled: typeof id === 'number',
+  });
+}
+
+export function useCreateMission() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: MissionInput) => service.createMission(data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['missions'] });
+    },
+  });
+}
+
+export function useUpdateMission(id: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: MissionInput) => service.updateMission(id, data),
+    onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: ['missions'] });
+      qc.setQueryData(['mission', id], data);
+    },
+  });
+}
+
+export function useDeleteMission() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => service.deleteMission(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['missions'] });
+    },
+  });
+}

--- a/src/hooks/usePlanning.ts
+++ b/src/hooks/usePlanning.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import * as service from '../services/planning';
+
+export function usePlanningWeek(startISO: string) {
+  return useQuery({
+    queryKey: ['planning', startISO],
+    queryFn: () => service.getPlanningWeek(startISO),
+    enabled: Boolean(startISO),
+  });
+}
+
+export function usePublishRange() {
+  return useMutation({
+    mutationFn: (body: service.PublishRangeBody) => service.publishRange(body),
+  });
+}

--- a/src/hooks/useTemplates.ts
+++ b/src/hooks/useTemplates.ts
@@ -1,0 +1,53 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import * as service from '../services/templates';
+import type { TemplateInput } from '../types/template';
+
+export function useTemplatesList(params?: service.TemplateListParams) {
+  return useQuery({
+    queryKey: ['templates', params],
+    queryFn: () => service.listTemplates(params),
+  });
+}
+
+export function useTemplate(id: number) {
+  return useQuery({
+    queryKey: ['template', id],
+    queryFn: () => service.getTemplate(id),
+    enabled: typeof id === 'number',
+  });
+}
+
+export function useCreateTemplate() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: TemplateInput) => service.createTemplate(data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['templates'] }),
+  });
+}
+
+export function useUpdateTemplate(id: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: TemplateInput) => service.updateTemplate(id, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['templates'] });
+      qc.invalidateQueries({ queryKey: ['template', id] });
+    },
+  });
+}
+
+export function useDeleteTemplate() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => service.deleteTemplate(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['templates'] }),
+  });
+}
+
+export function useApplyTemplate(id: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: service.ApplyTemplateBody) => service.applyTemplate(id, body),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['missions'] }),
+  });
+}

--- a/src/hooks/useUsers.ts
+++ b/src/hooks/useUsers.ts
@@ -1,0 +1,42 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import * as service from '../services/users';
+import type { UserInput, UserUpdate } from '../types/user';
+
+export function useUsersList() {
+  return useQuery({ queryKey: ['users'], queryFn: service.listUsers });
+}
+
+export function useUser(id: number) {
+  return useQuery({
+    queryKey: ['user', id],
+    queryFn: () => service.getUser(id),
+    enabled: typeof id === 'number',
+  });
+}
+
+export function useCreateUser() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: UserInput) => service.createUser(data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['users'] }),
+  });
+}
+
+export function useUpdateUser(id: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: UserUpdate) => service.updateUser(id, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['users'] });
+      qc.invalidateQueries({ queryKey: ['user', id] });
+    },
+  });
+}
+
+export function useDeleteUser() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => service.deleteUser(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['users'] }),
+  });
+}

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -20,7 +20,9 @@ async function request(path: string, options: HttpOptions = {}, retry = false): 
     ...options.headers,
   };
   let body: BodyInit | undefined;
-  if (options.body !== undefined) {
+  if (options.body instanceof FormData) {
+    body = options.body;
+  } else if (options.body !== undefined) {
     headers['Content-Type'] = 'application/json';
     body = JSON.stringify(options.body);
   }
@@ -70,4 +72,3 @@ export async function http<T>(path: string, opts: HttpOptions = {}): Promise<T> 
   }
   return (await res.json()) as T;
 }
-

--- a/src/services/accounting.ts
+++ b/src/services/accounting.ts
@@ -1,0 +1,40 @@
+import { API_BASE, http } from '../lib/http';
+import { useAuthStore } from '../app/store/auth';
+import type { SummaryOut } from '../types/accounting';
+
+export interface SummaryParams {
+  from?: string;
+  to?: string;
+}
+
+function qs(params?: Record<string, unknown>) {
+  if (!params) return '';
+  const s = new URLSearchParams(
+    Object.entries(params)
+      .filter(([, v]) => v !== undefined && v !== null)
+      .map(([k, v]) => [k, String(v)])
+  );
+  const q = s.toString();
+  return q ? `?${q}` : '';
+}
+
+export function getSummary(params?: SummaryParams) {
+  return http<SummaryOut>(`/accounting/summary${qs(params as Record<string, unknown> | undefined)}`);
+}
+
+export async function exportCsv(params?: SummaryParams): Promise<Blob> {
+  const token = useAuthStore.getState().token;
+  const res = await fetch(`${API_BASE}/accounting/export${qs(params as Record<string, unknown> | undefined)}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+    credentials: 'include',
+  });
+  if (!res.ok) {
+    let message = res.statusText;
+    try {
+      const data = await res.json();
+      message = (data as { message?: string }).message ?? message;
+    } catch {}
+    throw { message, status: res.status };
+  }
+  return await res.blob();
+}

--- a/src/services/assignments.ts
+++ b/src/services/assignments.ts
@@ -1,0 +1,14 @@
+import { http } from '../lib/http';
+import type { Assignment, AssignmentInput } from '../types/assignment';
+
+export function listAssignments(missionId: number) {
+  return http<Assignment[]>(`/assignments/mission/${missionId}`);
+}
+
+export function addAssignment(data: AssignmentInput) {
+  return http<Assignment>('/assignments', { method: 'POST', body: data });
+}
+
+export function updateAssignment(id: number, data: Partial<AssignmentInput>) {
+  return http<Assignment>(`/assignments/${id}`, { method: 'PUT', body: data });
+}

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,19 @@
+import { http } from '../lib/http';
+import type { User, UserPrefs } from '../types/user';
+
+export interface LoginInput {
+  username: string;
+  password: string;
+}
+
+export function login(data: LoginInput) {
+  return http<{ token: string }>('/auth/token-json', { method: 'POST', body: data });
+}
+
+export function getMe() {
+  return http<User>('/auth/me');
+}
+
+export function updatePrefs(prefs: UserPrefs) {
+  return http<User>('/auth/me/prefs', { method: 'PUT', body: prefs });
+}

--- a/src/services/availability.ts
+++ b/src/services/availability.ts
@@ -1,0 +1,31 @@
+import { API_BASE, http } from '../lib/http';
+import { useAuthStore } from '../app/store/auth';
+
+export interface Availability {
+  [key: string]: unknown;
+}
+
+export function getAvailability() {
+  return http<Availability>('/me/availability');
+}
+
+export function updateAvailability(data: Availability) {
+  return http<Availability>('/me/availability', { method: 'PUT', body: data });
+}
+
+export async function downloadIcs(): Promise<Blob> {
+  const token = useAuthStore.getState().token;
+  const res = await fetch(`${API_BASE}/me/availability/ics`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+    credentials: 'include',
+  });
+  if (!res.ok) {
+    let message = res.statusText;
+    try {
+      const data = await res.json();
+      message = (data as { message?: string }).message ?? message;
+    } catch {}
+    throw { message, status: res.status };
+  }
+  return await res.blob();
+}

--- a/src/services/files.ts
+++ b/src/services/files.ts
@@ -1,0 +1,46 @@
+import { API_BASE } from '../lib/http';
+import { useAuthStore } from '../app/store/auth';
+import type { FileMeta } from '../types/files';
+import { http } from '../lib/http';
+
+export function listFiles(missionId: number) {
+  return http<FileMeta[]>(`/missions/${missionId}/files`);
+}
+
+export async function uploadFile(missionId: number, file: File): Promise<FileMeta> {
+  const token = useAuthStore.getState().token;
+  const form = new FormData();
+  form.append('file', file);
+  const res = await fetch(`${API_BASE}/missions/${missionId}/files`, {
+    method: 'POST',
+    body: form,
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+    credentials: 'include',
+  });
+  if (!res.ok) {
+    let message = res.statusText;
+    try {
+      const data = await res.json();
+      message = (data as { message?: string }).message ?? message;
+    } catch {}
+    throw { message, status: res.status };
+  }
+  return (await res.json()) as FileMeta;
+}
+
+export async function downloadIcs(missionId: number): Promise<Blob> {
+  const token = useAuthStore.getState().token;
+  const res = await fetch(`${API_BASE}/missions/${missionId}/ics`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+    credentials: 'include',
+  });
+  if (!res.ok) {
+    let message = res.statusText;
+    try {
+      const data = await res.json();
+      message = (data as { message?: string }).message ?? message;
+    } catch {}
+    throw { message, status: res.status };
+  }
+  return await res.blob();
+}

--- a/src/services/missionActions.ts
+++ b/src/services/missionActions.ts
@@ -1,0 +1,23 @@
+import { http } from '../lib/http';
+import type { Mission } from '../types/mission';
+
+export function publishMission(id: number) {
+  return http<Mission>(`/missions/${id}/publish`, { method: 'POST' });
+}
+
+export interface DuplicateBody {
+  title_suffix: string;
+  shift_days?: number;
+}
+
+export function duplicateMission(id: number, body: DuplicateBody) {
+  return http<Mission>(`/missions/${id}/duplicate`, { method: 'POST', body });
+}
+
+export function closeMission(id: number) {
+  return http<Mission>(`/missions/${id}/close`, { method: 'POST' });
+}
+
+export function cancelMission(id: number) {
+  return http<Mission>(`/missions/${id}/cancel`, { method: 'POST' });
+}

--- a/src/services/missions.ts
+++ b/src/services/missions.ts
@@ -1,0 +1,41 @@
+import { http } from '../lib/http';
+import type { Mission, MissionInput } from '../types/mission';
+
+export interface MissionListParams {
+  q?: string;
+  status?: string;
+  date_from?: string;
+  date_to?: string;
+  page?: number;
+}
+
+function qs(params?: Record<string, unknown>) {
+  if (!params) return '';
+  const s = new URLSearchParams(
+    Object.entries(params)
+      .filter(([, v]) => v !== undefined && v !== null)
+      .map(([k, v]) => [k, String(v)])
+  );
+  const q = s.toString();
+  return q ? `?${q}` : '';
+}
+
+export function listMissions(params?: MissionListParams) {
+  return http<Mission[]>(`/missions${qs(params as Record<string, unknown> | undefined)}`);
+}
+
+export function getMission(id: number) {
+  return http<Mission>(`/missions/${id}`);
+}
+
+export function createMission(data: MissionInput) {
+  return http<Mission>('/missions', { method: 'POST', body: data });
+}
+
+export function updateMission(id: number, data: MissionInput) {
+  return http<Mission>(`/missions/${id}`, { method: 'PUT', body: data });
+}
+
+export function deleteMission(id: number) {
+  return http<void>(`/missions/${id}`, { method: 'DELETE' });
+}

--- a/src/services/planning.ts
+++ b/src/services/planning.ts
@@ -1,0 +1,16 @@
+import { http } from '../lib/http';
+import type { WeekOut } from '../types/planning';
+
+export function getPlanningWeek(startISO: string) {
+  return http<WeekOut>(`/planning/week/${encodeURIComponent(startISO)}`);
+}
+
+export interface PublishRangeBody {
+  start: string;
+  end: string;
+  message?: string;
+}
+
+export function publishRange(body: PublishRangeBody) {
+  return http<void>('/planning/publish-range', { method: 'POST', body });
+}

--- a/src/services/templates.ts
+++ b/src/services/templates.ts
@@ -1,0 +1,49 @@
+import { http } from '../lib/http';
+import type { Template, TemplateInput } from '../types/template';
+import type { Mission } from '../types/mission';
+
+export interface TemplateListParams {
+  q?: string;
+}
+
+function qs(params?: Record<string, unknown>) {
+  if (!params) return '';
+  const s = new URLSearchParams(
+    Object.entries(params)
+      .filter(([, v]) => v !== undefined && v !== null)
+      .map(([k, v]) => [k, String(v)])
+  );
+  const q = s.toString();
+  return q ? `?${q}` : '';
+}
+
+export function listTemplates(params?: TemplateListParams) {
+  return http<Template[]>(`/templates${qs(params as Record<string, unknown> | undefined)}`);
+}
+
+export function getTemplate(id: number) {
+  return http<Template>(`/templates/${id}`);
+}
+
+export function createTemplate(data: TemplateInput) {
+  return http<Template>('/templates', { method: 'POST', body: data });
+}
+
+export function updateTemplate(id: number, data: TemplateInput) {
+  return http<Template>(`/templates/${id}`, { method: 'PUT', body: data });
+}
+
+export function deleteTemplate(id: number) {
+  return http<void>(`/templates/${id}`, { method: 'DELETE' });
+}
+
+export interface ApplyTemplateBody {
+  start: string;
+  end: string;
+  title_override?: string;
+  notes?: string;
+}
+
+export function applyTemplate(id: number, body: ApplyTemplateBody) {
+  return http<Mission>(`/templates/${id}/apply`, { method: 'POST', body });
+}

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -1,0 +1,22 @@
+import { http } from '../lib/http';
+import type { User, UserInput, UserUpdate } from '../types/user';
+
+export function listUsers() {
+  return http<User[]>('/admin/users');
+}
+
+export function getUser(id: number) {
+  return http<User>(`/admin/users/${id}`);
+}
+
+export function createUser(data: UserInput) {
+  return http<User>('/admin/users', { method: 'POST', body: data });
+}
+
+export function updateUser(id: number, data: UserUpdate) {
+  return http<User>(`/admin/users/${id}`, { method: 'PUT', body: data });
+}
+
+export function deleteUser(id: number) {
+  return http<void>(`/admin/users/${id}`, { method: 'DELETE' });
+}

--- a/src/types/accounting.ts
+++ b/src/types/accounting.ts
@@ -1,0 +1,5 @@
+export interface SummaryOut {
+  missions: number;
+  hours: number;
+  total_estimated: number;
+}

--- a/src/types/assignment.ts
+++ b/src/types/assignment.ts
@@ -1,0 +1,11 @@
+export interface Assignment {
+  id: number;
+  mission_id: number;
+  user_id?: number | null;
+  role_label: string;
+  status: string;
+  channel?: string | null;
+  responded_at?: string | null;
+}
+
+export type AssignmentInput = Omit<Assignment, 'id'>;

--- a/src/types/files.ts
+++ b/src/types/files.ts
@@ -1,0 +1,8 @@
+export interface FileMeta {
+  id: number;
+  name: string;
+  url: string;
+  content_type: string;
+  size: number;
+  created_at: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,7 @@
+export * from './user';
+export * from './mission';
+export * from './assignment';
+export * from './template';
+export * from './files';
+export * from './planning';
+export * from './accounting';

--- a/src/types/mission.ts
+++ b/src/types/mission.ts
@@ -1,0 +1,20 @@
+export interface Position {
+  label: string;
+  count: number;
+  skills: Record<string, unknown>;
+}
+
+export interface Mission {
+  id: number;
+  title: string;
+  start: string;
+  end: string;
+  location: string;
+  call_time?: string | null;
+  positions: Position[];
+  documents: string[];
+  status: string;
+  created_by: number;
+}
+
+export type MissionInput = Omit<Mission, 'id' | 'created_by'>;

--- a/src/types/planning.ts
+++ b/src/types/planning.ts
@@ -1,0 +1,11 @@
+import type { Mission } from './mission';
+
+export interface WeekDay {
+  date: string;
+  missions: Mission[];
+}
+
+export interface WeekOut {
+  start: string;
+  days: WeekDay[];
+}

--- a/src/types/template.ts
+++ b/src/types/template.ts
@@ -1,0 +1,10 @@
+import type { Position } from './mission';
+
+export interface Template {
+  id: number;
+  title: string;
+  positions: Position[];
+  notes?: string;
+}
+
+export type TemplateInput = Omit<Template, 'id'>;

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,24 @@
+export interface UserPrefs {
+  [key: string]: unknown;
+}
+
+export type UserRole = 'admin' | 'intermittent';
+
+export interface User {
+  id: number;
+  username: string;
+  email: string;
+  role: UserRole;
+  prefs: UserPrefs;
+  created_at: string;
+}
+
+export interface UserInput {
+  username: string;
+  email: string;
+  role: UserRole;
+  password: string;
+  prefs?: UserPrefs;
+}
+
+export type UserUpdate = Partial<Omit<UserInput, 'password'>>;


### PR DESCRIPTION
## Summary
- add DTO types for users, missions, assignments, templates, files, planning and accounting
- implement service modules mapping API endpoints
- expose React Query hooks for CRUD and domain actions

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a22921a5ac8330b7b36a61772d7d6a