### PR TITLE
feat: add ui primitives and dev sandbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@tanstack/react-query": "^5.40.1",
+        "lucide-react": "^0.344.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hot-toast": "^2.4.1",
@@ -3055,6 +3056,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.344.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.344.0.tgz",
+      "integrity": "sha512-6YyBnn91GB45VuVT96bYCOKElbJzUHqp65vX8cDcu55MQL9T969v4dhGClpljamuI/+KMO9P6w9Acq1CVQGvIQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/merge2": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react-dom": "^18.2.0",
     "react-hot-toast": "^2.4.1",
     "react-router-dom": "^6.21.2",
-    "zustand": "^4.5.2"
+    "zustand": "^4.5.2",
+    "lucide-react": "^0.344.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.21",

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import DashboardLayout from './layouts/DashboardLayout';
 import Login from '../pages/Login';
 import Dashboard from '../pages/Dashboard';
+import Dev from '../pages/Dev';
 import { useAuthStore } from './store/auth';
 
 function ProtectedRoute({ children }: { children: JSX.Element }) {
@@ -17,6 +18,7 @@ export default function Router() {
     <BrowserRouter>
       <Routes>
         <Route path="/login" element={<Login />} />
+        <Route path="/_dev" element={<Dev />} />
         <Route
           path="/"
           element={

--- a/src/components/common/ConfirmDialog.tsx
+++ b/src/components/common/ConfirmDialog.tsx
@@ -1,0 +1,27 @@
+import Button from '../ui/Button';
+import Modal from '../ui/Modal';
+
+interface Props {
+  open: boolean;
+  title: string;
+  description?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function ConfirmDialog({ open, title, description, onConfirm, onCancel }: Props) {
+  return (
+    <Modal open={open} onClose={onCancel}>
+      <h2 className="text-lg font-semibold mb-2">{title}</h2>
+      {description && <p className="mb-4 text-sm text-gray-600">{description}</p>}
+      <div className="flex justify-end gap-2">
+        <Button variant="secondary" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button variant="destructive" onClick={onConfirm}>
+          Confirm
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/common/DateRangePicker.tsx
+++ b/src/components/common/DateRangePicker.tsx
@@ -1,0 +1,26 @@
+import { ChangeEvent } from 'react';
+import Input from '../ui/Input';
+import Label from '../ui/Label';
+
+interface Props {
+  start: string;
+  end: string;
+  onChange: (range: { start: string; end: string }) => void;
+}
+
+export default function DateRangePicker({ start, end, onChange }: Props) {
+  const onStart = (e: ChangeEvent<HTMLInputElement>) => onChange({ start: e.target.value, end });
+  const onEnd = (e: ChangeEvent<HTMLInputElement>) => onChange({ start, end: e.target.value });
+  return (
+    <div className="flex items-end gap-2">
+      <div>
+        <Label htmlFor="date-start">Start</Label>
+        <Input id="date-start" type="date" value={start} onChange={onStart} />
+      </div>
+      <div>
+        <Label htmlFor="date-end">End</Label>
+        <Input id="date-end" type="date" value={end} onChange={onEnd} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/EmptyState.tsx
+++ b/src/components/common/EmptyState.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react';
+import Button from '../ui/Button';
+
+interface Props {
+  title: string;
+  actionLabel?: string;
+  onAction?: () => void;
+  children?: ReactNode;
+}
+
+export default function EmptyState({ title, actionLabel, onAction, children }: Props) {
+  return (
+    <div className="text-center py-10">
+      <p className="text-sm text-gray-600 mb-4">{title}</p>
+      {children}
+      {actionLabel && onAction && (
+        <Button onClick={onAction} variant="secondary">
+          {actionLabel}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -1,0 +1,31 @@
+import Button from '../ui/Button';
+
+interface Props {
+  page: number;
+  totalPages: number;
+  onChange: (page: number) => void;
+}
+
+export default function Pagination({ page, totalPages, onChange }: Props) {
+  return (
+    <div className="flex items-center gap-2">
+      <Button
+        variant="secondary"
+        onClick={() => onChange(Math.max(1, page - 1))}
+        disabled={page <= 1}
+      >
+        Prev
+      </Button>
+      <span className="text-sm">
+        {page} / {totalPages}
+      </span>
+      <Button
+        variant="secondary"
+        onClick={() => onChange(Math.min(totalPages, page + 1))}
+        disabled={page >= totalPages}
+      >
+        Next
+      </Button>
+    </div>
+  );
+}

--- a/src/components/common/SearchInput.tsx
+++ b/src/components/common/SearchInput.tsx
@@ -1,0 +1,15 @@
+import { InputHTMLAttributes } from 'react';
+import { Search } from 'lucide-react';
+import { cn } from '../../lib/cn';
+
+export default function SearchInput({ className, ...props }: InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <div className={cn('relative', className)}>
+      <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
+      <input
+        className="pl-7 pr-3 py-2 border rounded w-full text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        {...props}
+      />
+    </div>
+  );
+}

--- a/src/components/common/Toolbar.tsx
+++ b/src/components/common/Toolbar.tsx
@@ -1,0 +1,11 @@
+import { HTMLAttributes } from 'react';
+import { cn } from '../../lib/cn';
+
+export default function Toolbar({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('flex items-center justify-between gap-2 mb-4', className)}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,0 +1,24 @@
+import { HTMLAttributes } from 'react';
+import { cn } from '../../lib/cn';
+
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  variant?: 'default' | 'secondary' | 'destructive';
+}
+
+export default function Badge({ variant = 'default', className, ...props }: BadgeProps) {
+  const variants = {
+    default: 'bg-blue-100 text-blue-800',
+    secondary: 'bg-gray-100 text-gray-800',
+    destructive: 'bg-red-100 text-red-800',
+  };
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded px-2 py-0.5 text-xs font-semibold',
+        variants[variant],
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,50 @@
+import { forwardRef, ButtonHTMLAttributes } from 'react';
+import { LucideIcon, Plus, Search, Trash2, Menu } from 'lucide-react';
+import { cn } from '../../lib/cn';
+
+const variantClasses = {
+  default: 'bg-blue-600 text-white hover:bg-blue-700',
+  secondary: 'bg-gray-100 text-gray-900 hover:bg-gray-200',
+  destructive: 'bg-red-600 text-white hover:bg-red-700',
+  ghost: 'bg-transparent hover:bg-gray-100',
+  link: 'underline text-blue-600 hover:text-blue-700',
+};
+
+const variantIcons: Record<Variant, LucideIcon | null> = {
+  default: Plus,
+  secondary: Search,
+  destructive: Trash2,
+  ghost: Menu,
+  link: null,
+};
+
+export type Variant = keyof typeof variantClasses;
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: Variant;
+  icon?: LucideIcon | null;
+}
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ variant = 'default', className, icon, children, ...props }, ref) => {
+    const Icon = icon ?? variantIcons[variant];
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          'inline-flex items-center justify-center rounded px-3 py-2 text-sm font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed',
+          variantClasses[variant],
+          className,
+        )}
+        {...props}
+      >
+        {Icon && <Icon className="mr-2 h-4 w-4" aria-hidden="true" />}
+        {children}
+      </button>
+    );
+  },
+);
+
+Button.displayName = 'Button';
+
+export default Button;

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,30 @@
+import { HTMLAttributes } from 'react';
+import { cn } from '../../lib/cn';
+
+export interface CardProps extends HTMLAttributes<HTMLDivElement> {}
+
+export function Card({ className, children, ...props }: CardProps) {
+  return (
+    <div
+      className={cn('border rounded bg-white dark:bg-gray-800 dark:border-gray-700', className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function CardHeader({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('border-b px-4 py-2 font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+export function CardContent({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={cn('p-4', className)} {...props} />
+  );
+}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,21 @@
+import { forwardRef, InputHTMLAttributes } from 'react';
+import { cn } from '../../lib/cn';
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ className, ...props }, ref) => (
+    <input
+      ref={ref}
+      className={cn(
+        'border rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:border-gray-700',
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+
+Input.displayName = 'Input';
+
+export default Input;

--- a/src/components/ui/Label.tsx
+++ b/src/components/ui/Label.tsx
@@ -1,0 +1,18 @@
+import { forwardRef, LabelHTMLAttributes } from 'react';
+import { cn } from '../../lib/cn';
+
+export interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement> {}
+
+const Label = forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, ...props }, ref) => (
+    <label
+      ref={ref}
+      className={cn('block text-sm font-medium text-gray-700 dark:text-gray-300', className)}
+      {...props}
+    />
+  ),
+);
+
+Label.displayName = 'Label';
+
+export default Label;

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,37 @@
+import { ReactNode, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { cn } from '../../lib/cn';
+
+export interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export default function Modal({ open, onClose, children }: ModalProps) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    if (open) document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      aria-modal="true"
+      role="dialog"
+      onClick={onClose}
+    >
+      <div
+        className={cn('bg-white rounded shadow p-4', 'dark:bg-gray-800')}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,0 +1,23 @@
+import { forwardRef, SelectHTMLAttributes } from 'react';
+import { cn } from '../../lib/cn';
+
+export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {}
+
+const Select = forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className, children, ...props }, ref) => (
+    <select
+      ref={ref}
+      className={cn(
+        'border rounded px-3 py-2 text-sm bg-white dark:bg-gray-800 dark:border-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </select>
+  ),
+);
+
+Select.displayName = 'Select';
+
+export default Select;

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,0 +1,11 @@
+import { HTMLAttributes } from 'react';
+import { cn } from '../../lib/cn';
+
+export default function Skeleton({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('animate-pulse rounded bg-gray-200 dark:bg-gray-700', className)}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/Table.tsx
+++ b/src/components/ui/Table.tsx
@@ -1,0 +1,35 @@
+import { HTMLAttributes } from 'react';
+import { cn } from '../../lib/cn';
+
+export function Table({ className, ...props }: HTMLAttributes<HTMLTableElement>) {
+  return (
+    <table className={cn('w-full text-left border-collapse', className)} {...props} />
+  );
+}
+
+export function THead({ className, ...props }: HTMLAttributes<HTMLTableSectionElement>) {
+  return (
+    <thead className={cn('bg-gray-50', className)} {...props} />
+  );
+}
+
+export function TBody({ className, ...props }: HTMLAttributes<HTMLTableSectionElement>) {
+  return <tbody className={className} {...props} />;
+}
+
+export function TR({ className, ...props }: HTMLAttributes<HTMLTableRowElement>) {
+  return <tr className={cn('border-b last:border-b-0', className)} {...props} />;
+}
+
+export function TH({ className, ...props }: HTMLAttributes<HTMLTableCellElement>) {
+  return (
+    <th
+      className={cn('px-2 py-1 text-sm font-medium text-gray-700', className)}
+      {...props}
+    />
+  );
+}
+
+export function TD({ className, ...props }: HTMLAttributes<HTMLTableCellElement>) {
+  return <td className={cn('px-2 py-1 text-sm', className)} {...props} />;
+}

--- a/src/components/ui/Tabs.tsx
+++ b/src/components/ui/Tabs.tsx
@@ -1,0 +1,43 @@
+import { createContext, ReactNode, useContext, useState } from 'react';
+import { cn } from '../../lib/cn';
+
+interface TabsContextValue {
+  active: string;
+  setActive: (value: string) => void;
+}
+
+const TabsContext = createContext<TabsContextValue | undefined>(undefined);
+
+export function Tabs({ defaultValue, children }: { defaultValue: string; children: ReactNode }) {
+  const [active, setActive] = useState(defaultValue);
+  return (
+    <TabsContext.Provider value={{ active, setActive }}>{children}</TabsContext.Provider>
+  );
+}
+
+export function TabsList({ className, children }: { className?: string; children: ReactNode }) {
+  return <div className={cn('flex border-b', className)}>{children}</div>;
+}
+
+export function TabsTrigger({ value, children }: { value: string; children: ReactNode }) {
+  const ctx = useContext(TabsContext);
+  if (!ctx) throw new Error('TabsTrigger must be used within Tabs');
+  const isActive = ctx.active === value;
+  return (
+    <button
+      onClick={() => ctx.setActive(value)}
+      className={cn(
+        'px-4 py-2 text-sm',
+        isActive ? 'border-b-2 border-blue-600 text-blue-600' : 'text-gray-600',
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function TabsContent({ value, children }: { value: string; children: ReactNode }) {
+  const ctx = useContext(TabsContext);
+  if (!ctx) throw new Error('TabsContent must be used within Tabs');
+  return ctx.active === value ? <div className="p-4">{children}</div> : null;
+}

--- a/src/components/ui/Textarea.tsx
+++ b/src/components/ui/Textarea.tsx
@@ -1,0 +1,21 @@
+import { forwardRef, TextareaHTMLAttributes } from 'react';
+import { cn } from '../../lib/cn';
+
+export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => (
+    <textarea
+      ref={ref}
+      className={cn(
+        'border rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:border-gray-700',
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+
+Textarea.displayName = 'Textarea';
+
+export default Textarea;

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,0 +1,7 @@
+import { Toaster, toast } from 'react-hot-toast';
+
+export { toast };
+
+export default function Toast() {
+  return <Toaster position="top-right" />;
+}

--- a/src/lib/cn.ts
+++ b/src/lib/cn.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ');
+}

--- a/src/pages/Dev.tsx
+++ b/src/pages/Dev.tsx
@@ -1,0 +1,138 @@
+import { useState } from 'react';
+import Button from '../components/ui/Button';
+import Input from '../components/ui/Input';
+import Label from '../components/ui/Label';
+import Select from '../components/ui/Select';
+import Textarea from '../components/ui/Textarea';
+import Badge from '../components/ui/Badge';
+import { Card, CardHeader, CardContent } from '../components/ui/Card';
+import { Table, THead, TBody, TR, TH, TD } from '../components/ui/Table';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '../components/ui/Tabs';
+import Modal from '../components/ui/Modal';
+import Toast, { toast } from '../components/ui/Toast';
+import Skeleton from '../components/ui/Skeleton';
+import Toolbar from '../components/common/Toolbar';
+import SearchInput from '../components/common/SearchInput';
+import Pagination from '../components/common/Pagination';
+import EmptyState from '../components/common/EmptyState';
+import ConfirmDialog from '../components/common/ConfirmDialog';
+import DateRangePicker from '../components/common/DateRangePicker';
+
+export default function Dev() {
+  const [open, setOpen] = useState(false);
+  const [confirm, setConfirm] = useState(false);
+  const [range, setRange] = useState({ start: '', end: '' });
+
+  return (
+    <div className="p-4 space-y-8">
+      <section>
+        <h2 className="mb-2 font-semibold">Buttons</h2>
+        <div className="flex flex-wrap gap-2">
+          <Button onClick={() => toast.success('Clicked')}>Default</Button>
+          <Button variant="secondary">Secondary</Button>
+          <Button variant="destructive">Destructive</Button>
+          <Button variant="ghost">Ghost</Button>
+          <Button variant="link">Link</Button>
+        </div>
+      </section>
+
+      <section className="space-y-2">
+        <h2 className="font-semibold">Form</h2>
+        <div className="flex flex-col gap-2 w-64">
+          <div>
+            <Label htmlFor="name">Name</Label>
+            <Input id="name" placeholder="Your name" />
+          </div>
+          <div>
+            <Label htmlFor="role">Role</Label>
+            <Select id="role" defaultValue="user">
+              <option value="admin">Admin</option>
+              <option value="user">User</option>
+            </Select>
+          </div>
+          <div>
+            <Label htmlFor="bio">Bio</Label>
+            <Textarea id="bio" rows={3} />
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2 className="mb-2 font-semibold">Badge & Card</h2>
+        <Badge className="mr-2">New</Badge>
+        <Card className="w-64 mt-2">
+          <CardHeader>Card Header</CardHeader>
+          <CardContent>Content</CardContent>
+        </Card>
+      </section>
+
+      <section>
+        <h2 className="mb-2 font-semibold">Table</h2>
+        <Table className="w-full max-w-md">
+          <THead>
+            <TR>
+              <TH>Name</TH>
+              <TH>Role</TH>
+            </TR>
+          </THead>
+          <TBody>
+            <TR>
+              <TD>Alice</TD>
+              <TD>Admin</TD>
+            </TR>
+          </TBody>
+        </Table>
+      </section>
+
+      <section>
+        <h2 className="mb-2 font-semibold">Tabs</h2>
+        <Tabs defaultValue="one">
+          <TabsList>
+            <TabsTrigger value="one">One</TabsTrigger>
+            <TabsTrigger value="two">Two</TabsTrigger>
+          </TabsList>
+          <TabsContent value="one">First tab</TabsContent>
+          <TabsContent value="two">Second tab</TabsContent>
+        </Tabs>
+      </section>
+
+      <section>
+        <h2 className="mb-2 font-semibold">Modal & Dialog</h2>
+        <Button onClick={() => setOpen(true)}>Open Modal</Button>
+        <Button variant="secondary" className="ml-2" onClick={() => setConfirm(true)}>
+          Confirm
+        </Button>
+        <Modal open={open} onClose={() => setOpen(false)}>
+          <p>Modal content</p>
+        </Modal>
+        <ConfirmDialog
+          open={confirm}
+          title="Are you sure?"
+          onCancel={() => setConfirm(false)}
+          onConfirm={() => setConfirm(false)}
+        />
+      </section>
+
+      <section>
+        <h2 className="mb-2 font-semibold">Toast & Skeleton</h2>
+        <Button onClick={() => toast.success('Hello')}>Show Toast</Button>
+        <Skeleton className="h-4 w-32 mt-2" />
+      </section>
+
+      <section>
+        <h2 className="mb-2 font-semibold">Toolbar & SearchInput & Pagination</h2>
+        <Toolbar>
+          <SearchInput placeholder="Search" />
+          <Pagination page={1} totalPages={5} onChange={() => {}} />
+        </Toolbar>
+      </section>
+
+      <section>
+        <h2 className="mb-2 font-semibold">EmptyState & DateRangePicker</h2>
+        <EmptyState title="No data" actionLabel="Reload" onAction={() => {}} />
+        <DateRangePicker start={range.start} end={range.end} onChange={setRange} />
+      </section>
+      <Toast />
+    </div>
+  );
+}

--- a/src/services/accounting.ts
+++ b/src/services/accounting.ts
@@ -33,7 +33,9 @@ export async function exportCsv(params?: SummaryParams): Promise<Blob> {
     try {
       const data = await res.json();
       message = (data as { message?: string }).message ?? message;
-    } catch {}
+    } catch {
+      /* ignore */
+    }
     throw { message, status: res.status };
   }
   return await res.blob();

--- a/src/services/availability.ts
+++ b/src/services/availability.ts
@@ -24,7 +24,9 @@ export async function downloadIcs(): Promise<Blob> {
     try {
       const data = await res.json();
       message = (data as { message?: string }).message ?? message;
-    } catch {}
+    } catch {
+      /* ignore */
+    }
     throw { message, status: res.status };
   }
   return await res.blob();

--- a/src/services/files.ts
+++ b/src/services/files.ts
@@ -22,7 +22,9 @@ export async function uploadFile(missionId: number, file: File): Promise<FileMet
     try {
       const data = await res.json();
       message = (data as { message?: string }).message ?? message;
-    } catch {}
+    } catch {
+      /* ignore */
+    }
     throw { message, status: res.status };
   }
   return (await res.json()) as FileMeta;
@@ -39,7 +41,9 @@ export async function downloadIcs(missionId: number): Promise<Blob> {
     try {
       const data = await res.json();
       message = (data as { message?: string }).message ?? message;
-    } catch {}
+    } catch {
+      /* ignore */
+    }
     throw { message, status: res.status };
   }
   return await res.blob();


### PR DESCRIPTION
## Summary
- add foundational UI components with lucide icon support
- expose story-style sandbox at `/_dev` to demo primitives
- wire lint fixes and dependency for lucide-react

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a22c1b6618833095e6deadd1bfbd68