### PR TITLE
feat: add caddy reverse proxy for local dev

### DIFF
--- a/.env
+++ b/.env
@@ -6,9 +6,9 @@ POSTGRES_DB=appdb
 API_HOST=0.0.0.0
 API_PORT=8001
 TOKEN_TTL_MINUTES=120
-CORS_ORIGINS=http://localhost:5173
+CORS_ORIGINS=http://localhost
 # Frontend
-VITE_API_BASE=http://localhost:8001
+VITE_API_BASE=http://localhost/api
 # Proxy
 PROXY_SITE=http://localhost
 # Misc

--- a/README_PROXY.md
+++ b/README_PROXY.md
@@ -1,0 +1,26 @@
+Reverse proxy
+==============
+
+Caddy runs as an HTTP reverse proxy for local development. HTTPS is intentionally disabled to avoid certificate prompts on Windows.
+
+Usage
+-----
+
+1. Start the stack:
+
+   docker compose up -d
+
+2. Format the Caddyfile inside the proxy container when updating it:
+
+   docker compose exec proxy caddy fmt --overwrite /etc/caddy/Caddyfile
+
+Health checks
+-------------
+
+Verify the proxy and upstreams:
+
+```
+curl http://localhost/_proxy/health
+curl http://localhost/api/healthz
+curl http://localhost/
+```

--- a/compose.yaml
+++ b/compose.yaml
@@ -38,11 +38,16 @@ services:
     image: caddy:2.8
     volumes:
       - ./ops/Caddyfile:/etc/caddy/Caddyfile
+    depends_on:
+      - api
+      - frontend
     ports:
       - "80:80"
-    depends_on:
-      - frontend
-      - api
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost/_proxy/health"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
     networks:
       - appnet
 networks:

--- a/ops/Caddyfile
+++ b/ops/Caddyfile
@@ -1,8 +1,23 @@
-:80
-encode gzip
-handle_path /api/* {
-  reverse_proxy api:8001
-}
-handle {
-  reverse_proxy frontend:5173
+# Local development proxy. HTTPS intentionally disabled to avoid certificate prompts on Windows.
+
+:80 {
+  encode gzip
+
+  @api path /api/*
+  handle @api {
+    header_up Host {http.request.host}
+    header_up X-Forwarded-For {http.request.remote}
+    header_up X-Forwarded-Proto {http.request.proto}
+    handle_path /api/* {
+      reverse_proxy api:8001
+    }
+  }
+
+  handle_path /_proxy/health* {
+    respond "ok" 200
+  }
+
+  handle {
+    reverse_proxy frontend:5173
+  }
 }


### PR DESCRIPTION
## Summary
- route /api and frontend traffic through caddy proxy
- declare proxy service in compose with health checks
- document proxy usage and health commands

## Testing
- `docker compose config --services` *(fails: command not found)*
- `curl http://localhost/_proxy/health` *(fails: connection refused)*
- `curl http://localhost/api/healthz` *(fails: connection refused)*
- `curl http://localhost/` *(fails: connection refused)*
- `caddy fmt ops/Caddyfile` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a22e6a24488330825c08cbbca0ea8c