### PR TITLE
Add database init and admin seeding

### DIFF
--- a/README_DB.md
+++ b/README_DB.md
@@ -1,0 +1,15 @@
+# Database Helpers
+
+- Start servers (oper):
+  docker compose up -d --build
+
+- Run Python tests:
+  docker compose exec api pytest -q
+  or: scripts\test_py.ps1
+
+- Force re-apply schema + seed on demand:
+  scripts\seed_admin.ps1
+
+- Direct one-liners (without scripts):
+  docker compose exec db psql -U postgres -d appdb -f /sql/schema.sql
+  docker compose exec db psql -U postgres -d appdb -f /sql/seed_admin.sql

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,9 +6,28 @@ services:
     volumes:
       - ./data/db:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
-    networks:
-      - appnet
+      test: ["CMD-SHELL","pg_isready -U ${POSTGRES_USER:-postgres}"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    networks: [appnet]
+
+  db-init:
+    image: postgres:15
+    env_file: .env
+    depends_on:
+      db:
+        condition: service_healthy
+    volumes:
+      - ./sql:/sql:ro
+    command: >
+      bash -lc "
+      psql -h db -U ${POSTGRES_USER} -d ${POSTGRES_DB} -f /sql/schema.sql &&
+      psql -h db -U ${POSTGRES_USER} -d ${POSTGRES_DB} -f /sql/seed_admin.sql
+      "
+    restart: "no"
+    networks: [appnet]
+
   api:
     build: ./api
     command: gunicorn -k uvicorn.workers.UvicornWorker -w 4 -b 0.0.0.0:8001 app.main:app
@@ -16,6 +35,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      db-init:
+        condition: service_completed_successfully
     ports:
       - "8001:8001"
     healthcheck:

--- a/scripts/seed_admin.ps1
+++ b/scripts/seed_admin.ps1
@@ -1,0 +1,9 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+Set-Location $PSScriptRoot\..
+docker compose exec db psql -U postgres -d appdb -c `
+  "CREATE EXTENSION IF NOT EXISTS pgcrypto;"
+docker compose exec db psql -U postgres -d appdb -f /sql/schema.sql
+docker compose exec db psql -U postgres -d appdb -f /sql/seed_admin.sql
+docker compose exec db psql -U postgres -d appdb -c `
+  "SELECT id, username, role, created_at FROM users WHERE username='admin';"

--- a/scripts/start_oper.ps1
+++ b/scripts/start_oper.ps1
@@ -1,6 +1,6 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
 Set-Location $PSScriptRoot\..
-docker compose down
-docker compose build --no-cache
-docker compose up -d
+docker compose up -d --build
 docker compose ps
 docker compose logs api --tail=200

--- a/scripts/test_py.ps1
+++ b/scripts/test_py.ps1
@@ -1,0 +1,9 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+Set-Location $PSScriptRoot\..
+try {
+  docker compose exec api pytest -q
+} catch {
+  Write-Host "pytest failed or not installed"
+  exit 1
+}

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,0 +1,9 @@
+-- Idempotent schema for users
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE TABLE IF NOT EXISTS users (
+  id BIGSERIAL PRIMARY KEY,
+  username TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,
+  role TEXT NOT NULL CHECK (role IN ('admin','intermittent')),
+  created_at TIMESTAMPTZ DEFAULT now()
+);

--- a/sql/seed_admin.sql
+++ b/sql/seed_admin.sql
@@ -1,0 +1,8 @@
+-- Idempotent admin seeding
+INSERT INTO users (username, password_hash, role)
+VALUES (
+  'admin',
+  crypt('admin123', gen_salt('bf')),
+  'admin'
+)
+ON CONFLICT (username) DO NOTHING;


### PR DESCRIPTION
## Summary
- add sql scripts to initialize users table and seed admin
- run db-init service in compose to apply schema and seeding
- add helper scripts and README for database operations

## Testing
- `pytest -q` *(fails: pydantic_settings.exceptions.SettingsError: error parsing value for field "cors_origins" from source "DotEnvSettingsSource")*
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a234340b9483308e135974f7d8d22c