### PR TITLE
feat: add token-based auth endpoints

### DIFF
--- a/api/app/db.py
+++ b/api/app/db.py
@@ -1,6 +1,7 @@
 import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from typing import Generator
 
 DB_USER = os.getenv("POSTGRES_USER", "postgres")
 DB_PASSWORD = os.getenv("POSTGRES_PASSWORD", "postgres")
@@ -11,3 +12,11 @@ DATABASE_URL = f"postgresql+psycopg://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:5432/{DB
 
 engine = create_engine(DATABASE_URL, future=True)
 SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+
+def get_db() -> Generator:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,7 +1,33 @@
 from fastapi import FastAPI
 
+from .db import engine
+from .routers.auth import router as auth_router
+
 app = FastAPI()
+
+
+@app.on_event("startup")
+def startup() -> None:
+    with engine.begin() as conn:
+        conn.exec_driver_sql(
+            """
+            CREATE TABLE IF NOT EXISTS auth_tokens (
+              token TEXT PRIMARY KEY,
+              user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+              expires_at TIMESTAMPTZ NOT NULL,
+              created_at TIMESTAMPTZ DEFAULT now()
+            );
+            """
+        )
+        conn.exec_driver_sql(
+            """
+            CREATE INDEX IF NOT EXISTS idx_auth_tokens_user_expires ON auth_tokens(user_id, expires_at);
+            """
+        )
 
 @app.get("/healthz")
 def healthz():
     return {"ok": True}
+
+
+app.include_router(auth_router, prefix="/auth", tags=["auth"])

--- a/api/app/routers/auth.py
+++ b/api/app/routers/auth.py
@@ -1,0 +1,68 @@
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from ..db import get_db
+from ..security import (
+    TOKEN_TTL_MINUTES,
+    bearer_scheme,
+    create_token,
+    get_current_user,
+    verify_password,
+)
+
+router = APIRouter()
+
+
+class TokenRequest(BaseModel):
+    username: str
+    password: str
+
+
+@router.post("/token-json")
+def token_json(payload: TokenRequest, db: Session = Depends(get_db)):
+    user_query = text(
+        "SELECT id, username, password_hash, role FROM users WHERE username = :u"
+    )
+    user = db.execute(user_query, {"u": payload.username}).mappings().first()
+    if not user or not verify_password(payload.password, user["password_hash"]):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+
+    token = create_token()
+    expires_at = datetime.now(timezone.utc) + timedelta(minutes=TOKEN_TTL_MINUTES)
+    insert_query = text(
+        """
+        INSERT INTO auth_tokens(token, user_id, expires_at)
+        VALUES (:t, :uid, :exp)
+        """
+    )
+    db.execute(insert_query, {"t": token, "uid": user["id"], "exp": expires_at})
+    db.commit()
+    return {
+        "access_token": token,
+        "token_type": "bearer",
+        "expires_in": TOKEN_TTL_MINUTES * 60,
+    }
+
+
+@router.get("/me")
+def read_me(current_user=Depends(get_current_user)):
+    return {
+        "id": current_user["id"],
+        "username": current_user["username"],
+        "role": current_user["role"],
+    }
+
+
+@router.post("/logout")
+def logout(
+    credentials=Depends(bearer_scheme),
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    db.execute(text("DELETE FROM auth_tokens WHERE token = :t"), {"t": credentials.credentials})
+    db.commit()
+    return {"ok": True}

--- a/api/app/security.py
+++ b/api/app/security.py
@@ -1,0 +1,44 @@
+import os
+import secrets
+
+import bcrypt
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from .db import get_db
+
+TOKEN_TTL_MINUTES = int(os.getenv("TOKEN_TTL_MINUTES", "120"))
+
+bearer_scheme = HTTPBearer(auto_error=False)
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return bcrypt.checkpw(plain_password.encode(), hashed_password.encode())
+
+
+def create_token() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
+    db: Session = Depends(get_db),
+):
+    if not credentials or credentials.scheme.lower() != "bearer":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+
+    token = credentials.credentials
+    query = text(
+        """
+        SELECT u.id, u.username, u.role
+        FROM auth_tokens t
+        JOIN users u ON u.id = t.user_id
+        WHERE t.token = :token AND t.expires_at > now()
+        """
+    )
+    result = db.execute(query, {"token": token}).mappings().first()
+    if not result:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+    return result


### PR DESCRIPTION
## Summary
- add SQL startup migration for auth_tokens table
- implement token-based login, profile and logout endpoints
- add password and token helpers

## Testing
- `python -m py_compile api/app/db.py api/app/security.py api/app/routers/auth.py api/app/main.py`
- `CORS_ORIGINS='[]' pytest` *(fails: pydantic_settings.exceptions.SettingsError: error parsing value for field "cors_origins" from source "DotEnvSettingsSource")*

------
https://chatgpt.com/codex/tasks/task_e_68a23bd7e4988330b01fcee233ccc3c3